### PR TITLE
Added some clarification around permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,9 +117,10 @@ Choose your API and click the 'Settings' panel.
 
 Scroll down to the section titled 'RBAC Settings'.
 
-Ensure the following settings are enabled:
-	-Enable RBAC
-	- Add Permissions in the Access Token
+Ensure the following settings are **enabled**:
+
+- Enable RBAC
+- Add Permissions in the Access Token
 
 Your ASP.NET code should now be able to examine these permissions correctly.
 

--- a/README.md
+++ b/README.md
@@ -111,6 +111,18 @@ The `/admin` endpoint requires the access token to contain the `read:admin-messa
 
 You can use the Auth0 Dashboard to create an `admin` role and assign it the`read:admin-messages` permission. Then, you can assign the `admin` role to any user that you want to access the `/admin` endpoint.
 
+You can assign these permissions by going to the Auth0 Dashboard.
+
+Choose your API and click the 'Settings' panel.
+
+Scroll down to the section titled 'RBAC Settings'.
+
+Ensure the following settings are enabled:
+	-Enable RBAC
+	- Add Permissions in the Access Token
+
+Your ASP.NET code should now be able to examine these permissions correctly.
+
 ## API Endpoints
 
 ### 🔓 Get public message


### PR DESCRIPTION
Hello,

I wanted to include some clarification around setting permission on the API. The current code examples make some assumptions about the Enable RBAC and Add Permissions in the Access Token being enabled, but it wasn't spelled out clearly in the examples. I'm hoping this will help some other devs out when using these samples. I couldn't figure out why the code was not asserting the permission existed, even though I could see it in the request to Auth0. 

Open to any and all suggestions on the feedback. Thanks for your time! 🕐 👍🏻 